### PR TITLE
Add y axis labels and legend to TypeScript progress graph

### DIFF
--- a/visualisation/line-graph.ts
+++ b/visualisation/line-graph.ts
@@ -90,7 +90,15 @@ const yAxis = (sections: number): string => {
   const marks = Array(sections - 1).fill(yScale.domain()[1])
     .map((max, count) => {
       const y = yScale((count + 1) * max / sections);
-      return `<path d="M 0,${Math.round(y)} h${width}" />`;
+      const yLabel = ((count + 1) * max / sections) * 100;
+      return `<path d="M 20,${Math.round(y)} h${width}" />
+      <g transform="translate(0, ${Math.round(y)})">
+      <text text-anchor="middle"
+      fill="black"
+      stroke="none"
+      transform="translate(0, 3)">${Math.round(yLabel)}%</text>
+      <path d="M0,v-5 0" />
+      </g>`;
     });
 
   return marks.join("");
@@ -109,7 +117,7 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
       font-size: 12px;
     }
   </style>
-  <g class="lines" fill="none">
+  <g class="lines" fill="none" transform="translate(20, 0)">>
     ${path("percentage", { stroke: "darkblue" })}
     ${path("percentageSize", { stroke: "blue" })}
     
@@ -117,13 +125,13 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
     ${path("percentageSize", { stroke: "orange", typed: false })}
   </g>
   
-  <g class="axis y" stroke="black" fill="none" stroke-dasharray="4 6">
+  <g class="axis y" stroke="black" fill="none" stroke-dasharray="4 6" transform="translate(10, 0)">
     ${yAxis(4)}
   </g>
   <g
     class="axis x"
     stroke="black" fill="none"
-    transform="translate(0, ${height - 20})">
+    transform="translate(20, ${height - 20})">
   ${xAxis()}
   </g>
 </svg>`;

--- a/visualisation/line-graph.ts
+++ b/visualisation/line-graph.ts
@@ -16,13 +16,13 @@ const data: Progress[] = JSON.parse(
 
 // Dimensions //
 const width = 900;
-const height = 400;
+const height = 460;
 
 const now = new Date();
 
 const yScale = scaleLinear()
   .domain([0, 1])
-  .range([height - 20, 0]); // note direction of y-axis in SVG
+  .range([height - 100, 0]); // note direction of y-axis in SVG
 
 const xScale = scaleTime()
   .domain([
@@ -100,7 +100,14 @@ const yAxis = (sections: number): string => {
       <path d="M0,v-5 0" />
       </g>`;
     });
-
+  marks.push(`<path d="M 20,${Math.round(yScale(1))} h${width}" />
+    <g transform="translate(0, ${Math.round(yScale(1))})">
+    <text text-anchor="middle"
+    fill="black"
+    stroke="none"
+    transform="translate(0, 3)">${Math.round(100)}%</text>
+    <path d="M0,v-5 0" />
+    </g>`);
   return marks.join("");
 };
 
@@ -117,7 +124,7 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
       font-size: 12px;
     }
   </style>
-  <g class="lines" fill="none" transform="translate(20, 0)">>
+  <g class="lines" fill="none" transform="translate(20, 80)">>
     ${path("percentage", { stroke: "darkblue" })}
     ${path("percentageSize", { stroke: "blue" })}
     
@@ -125,7 +132,7 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
     ${path("percentageSize", { stroke: "orange", typed: false })}
   </g>
   
-  <g class="axis y" stroke="black" fill="none" stroke-dasharray="4 6" transform="translate(10, 0)">
+  <g class="axis y" stroke="black" fill="none" stroke-dasharray="4 6" transform="translate(20, 80)">
     ${yAxis(4)}
   </g>
   <g

--- a/visualisation/line-graph.ts
+++ b/visualisation/line-graph.ts
@@ -134,6 +134,22 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
     transform="translate(20, ${height - 20})">
   ${xAxis()}
   </g>
+  <g class="legend" transform="translate(20,10)">
+    <rect width="18" height="18" style="fill: darkblue; stroke: darkblue;"></rect>
+    <text x="22" y="14">TypeScript (by file number)</text>
+  </g>
+  <g class="legend" transform="translate(20,30)">
+    <rect width="18" height="18" style="fill: blue; stroke: blue;"></rect>
+    <text x="22" y="14">TypeScript (by file size)</text>
+  </g>
+  <g class="legend" transform="translate(260,10)">
+    <rect width="18" height="18" style="fill: darkorange; stroke: darkorange;"></rect>
+    <text x="22" y="14">JavaScript (by file number)</text>
+  </g>
+  <g class="legend" transform="translate(260,30)">
+    <rect width="18" height="18" style="fill: orange; stroke: orange;"></rect>
+    <text x="22" y="14">JavaScript (by file size)</text>
+  </g>
 </svg>`;
 
 Deno.writeTextFileSync(dir + "../public/build/progress.svg", svg);


### PR DESCRIPTION
## What does this change?

Adding labels to the y axis and a legend to the graph to help make it easier to read and clearer.

## How to test

You can view the updated graphic by running the build.sh file locally and opening the html page on your browser.

## How can we measure success?

Graph should be easier to understand for those who haven't used it before

## Images

Updated graph looks like this:

<img width="949" alt="Screenshot 2022-09-07 at 17 23 23" src="https://user-images.githubusercontent.com/108270776/188930151-99b77115-3bb4-49bc-b7bc-0b71b3926d81.png">
