### PR TITLE
Update folders display and add % progress

### DIFF
--- a/visualisation/README.md
+++ b/visualisation/README.md
@@ -1,10 +1,7 @@
 # Commercial Bundle Visualisation
 
-> Some info about the visualisation
-
-> A generated static svg
-
-> A link to the dynamic, updated graph?
+This folder contains the files which are used to build the graphs shown here:
+https://guardian.github.io/commercial-bundle-progress/index.html
 
 ## Local development
 
@@ -13,3 +10,26 @@ You need `Deno`, which can be installed via `brew install deno`.
 ```bash
 deno bundle index.js public/build/bundle.js --config=tsconfig.json --watch
 ```
+
+## Running the graph page
+
+Install deno file_server, using the following command:
+
+```bash
+deno install --allow-net --allow-read https://deno.land/std@0.155.0/http/file_server.ts
+```
+
+To build the bundle, run this command inside the repository folder:
+
+```bash
+scripts/build.sh
+```
+
+Then use file_server to build the bundle locally:
+
+```bash
+~/.deno/bin/file_server public
+```
+
+This will give you a localhost address, which you can visit to see the node and
+line graphs.

--- a/visualisation/data.ts
+++ b/visualisation/data.ts
@@ -33,16 +33,6 @@ export enum Groups {
   Hosted,
 }
 
-const folders = [
-  "node_modules",
-  "/lib/",
-  "projects/commercial",
-  // "/messenger/",
-  // "/dfp/",
-  "/hosted/",
-  "projects/common",
-];
-
 const waitFor = (n = 600): Promise<void> =>
   new Promise((resolve) => {
     setTimeout(() => {
@@ -52,7 +42,8 @@ const waitFor = (n = 600): Promise<void> =>
 
 const [width, height] = [1200, 600];
 
-const xOrigin = (folder: number) => width * ((folder + 0.5) / folders.length);
+const xOrigin = (folder: number, foldersList: string[]) =>
+  width * ((folder + 0.5) / foldersList.length);
 
 let maximum = 0;
 const yOrigin = (size: number, max = maximum) =>
@@ -82,6 +73,40 @@ const getTree = async (sha: string) => {
   return tree;
 };
 
+const folders = [
+  "node_modules",
+  "/lib/",
+  "projects/commercial",
+  "/hosted/",
+  "projects/common",
+];
+
+const getFolders = async (sha: string) => {
+  const tree = await getTree(sha);
+
+  // config.d.ts can be safely ignored
+  delete tree["../lib/config.d.ts"];
+
+  let newFolders: string[] = [];
+
+  Object.entries(tree).forEach((entry) => {
+    const folder = folders.reduce((prev, current, index) => {
+      return entry[0].includes(current) ? index : prev;
+    }, 0);
+    let alreadyIn = false;
+    for (let i = 0; i < newFolders.length; i++) {
+      if (newFolders[i] == folders[folder]) {
+        alreadyIn = true;
+      }
+    }
+    if (!alreadyIn) {
+      newFolders.push(folders[folder]);
+    }
+  });
+
+  return newFolders;
+};
+
 const getDataForHash = async (sha = branch) => {
   const tree = await getTree(sha);
 
@@ -104,7 +129,25 @@ const getDataForHash = async (sha = branch) => {
     });
   });
 
-  console.log(tree);
+  let newFolders: string[] = [];
+
+  Object.entries(tree).forEach((entry) => {
+    const folder = folders.reduce((prev, current, index) => {
+      return entry[0].includes(current) ? index : prev;
+    }, 0);
+    let alreadyIn = false;
+    for (let i = 0; i < newFolders.length; i++) {
+      if (newFolders[i] == folders[folder]) {
+        alreadyIn = true;
+      }
+    }
+    if (!alreadyIn) {
+      newFolders.push(folders[folder]);
+    }
+  });
+
+  const adjustedXOrigin = (folder: number) =>
+    width * ((folder + 0.5) / newFolders.length);
 
   const nodes: Node[] = Object.entries(tree)
     .map<Node>((value) => {
@@ -117,7 +160,7 @@ const getDataForHash = async (sha = branch) => {
         ? Groups.Typescript
         : Groups.Javascript;
 
-      const folder = folders.reduce((prev, current, index) => {
+      const folder = newFolders.reduce((prev, current, index) => {
         return id.includes(current) ? index : prev;
       }, 0);
 
@@ -133,7 +176,7 @@ const getDataForHash = async (sha = branch) => {
       return node;
     })
     .map((node) => {
-      node.x = xOrigin(node.folder) - (simpleHash(node.id) % 31) + 15;
+      node.x = adjustedXOrigin(node.folder) - (simpleHash(node.id) % 31) + 15;
       node.y = yOrigin(node.imports, maxImports) - (simpleHash(node.id) % 29) +
         15;
       return node;
@@ -190,5 +233,14 @@ const hashes = [
   "main",
 ];
 
-export { folders, getDataForHash, getTree, height, width, xOrigin, yOrigin };
+export {
+  folders,
+  getDataForHash,
+  getFolders,
+  getTree,
+  height,
+  width,
+  xOrigin,
+  yOrigin,
+};
 export type { Data, Link, Node };

--- a/visualisation/directed-graph.ts
+++ b/visualisation/directed-graph.ts
@@ -4,13 +4,13 @@ import { schemeCategory10 } from "https://cdn.skypack.dev/d3-scale-chromatic@3?d
 import { scaleOrdinal } from "../d3/scale.ts";
 import { Data, Link, Node } from "./data.ts";
 import { height, width } from "./data.ts";
-import { folders, xOrigin, yOrigin } from "./data.ts";
+import { xOrigin, yOrigin } from "./data.ts";
 import type { Simulation } from "../d3/force.ts";
 import { dragging } from "./simulation.ts";
 
 /** ********************
  *      Constants     *
- * ******************** */
+ * *********************/
 
 const svg = create("svg").attr("viewBox", [0, 0, width, height].join(" "));
 
@@ -18,16 +18,11 @@ const scale = scaleOrdinal(schemeCategory10);
 
 const isNode = (n: string | Node): n is Node => typeof n !== "string";
 
-svg.append("g")
+const foldersGroup = svg.append("g")
   .attr("class", "folders")
-  .selectAll<Window, string>("text")
-  .data(folders)
-  .join("text")
-  .text((d) => d)
   .attr("font-size", 10)
   .attr("text-anchor", "middle")
-  .attr("y", 540)
-  .attr("x", (d) => xOrigin(folders.indexOf(d)));
+  .attr("y", 580);
 
 const linkGroup = svg.append("g")
   .attr("class", "links")
@@ -42,7 +37,11 @@ const _t = transition();
 
 const radius = (d: Node) => Math.sqrt(d.imports + 1) * 3 + 4;
 
-const updateSvgData = (data: Data, simulation: Simulation<Node, Link>) => {
+const updateSvgData = (
+  data: Data,
+  simulation: Simulation<Node, Link>,
+  updatedFolders: string[],
+) => {
   const { links, nodes } = data;
 
   // @ts-expect-error -- actually typeof d is Link
@@ -84,7 +83,8 @@ const updateSvgData = (data: Data, simulation: Simulation<Node, Link>) => {
           .attr("data-imports", (d) => d.imports)
           .attr(
             "data-origin",
-            (d) => `${xOrigin(d.imports)},${yOrigin(d.imports)}`,
+            (d) =>
+              `${xOrigin(d.imports, updatedFolders)},${yOrigin(d.imports)}`,
           )
           .call(dragging(simulation));
 
@@ -199,6 +199,16 @@ const updateSvgData = (data: Data, simulation: Simulation<Node, Link>) => {
     node
       .attr("transform", (d) => `translate(${d.x}, ${d.y})`);
   });
+
+  foldersGroup
+    .selectAll<Window, string>("text")
+    .data(updatedFolders)
+    .join("text")
+    .text((d) => d)
+    .attr("x", (d) => xOrigin(updatedFolders.indexOf(d), updatedFolders))
+    .attr("font-size", 10)
+    .attr("text-anchor", "middle")
+    .attr("y", 580);
 };
 
 export { height, radius, svg, updateSvgData, width };

--- a/visualisation/directed-graph.ts
+++ b/visualisation/directed-graph.ts
@@ -20,7 +20,7 @@ const isNode = (n: string | Node): n is Node => typeof n !== "string";
 
 const foldersGroup = svg.append("g")
   .attr("class", "folders")
-  .attr("font-size", 10)
+  .attr("font-size", 14)
   .attr("text-anchor", "middle")
   .attr("y", 580);
 
@@ -206,7 +206,7 @@ const updateSvgData = (
     .join("text")
     .text((d) => d)
     .attr("x", (d) => xOrigin(updatedFolders.indexOf(d), updatedFolders))
-    .attr("font-size", 10)
+    .attr("font-size", 14)
     .attr("text-anchor", "middle")
     .attr("y", 580);
 };

--- a/visualisation/index.ts
+++ b/visualisation/index.ts
@@ -1,5 +1,5 @@
 import { svg } from "./directed-graph.ts";
-import { getDataForHash } from "./data.ts";
+import { getDataForHash, getFolders } from "./data.ts";
 import { updateSimulationData } from "./simulation.ts";
 import { updateSvgData } from "./directed-graph.ts";
 
@@ -29,9 +29,10 @@ const hashes = [
 
 const updateGraph = async (hash: string) => {
   const data = await getDataForHash(hash);
-  const simulation = updateSimulationData(data);
+  const folders = await getFolders(hash);
+  const simulation = updateSimulationData(data, folders);
 
-  updateSvgData(data, simulation);
+  updateSvgData(data, simulation, folders);
 };
 updateGraph("main");
 

--- a/visualisation/line-graph.ts
+++ b/visualisation/line-graph.ts
@@ -121,6 +121,8 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
   <style>
     text {
       font-family: \"Courier New\", Courier, monospace;
+    }
+    .legend {
       font-size: 12px;
     }
   </style>
@@ -156,6 +158,11 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg"
   <g class="legend" transform="translate(260,30)">
     <rect width="18" height="18" style="fill: orange; stroke: orange;"></rect>
     <text x="22" y="14">JavaScript (by file size)</text>
+  </g>
+  <g class="total" transform="translate(570,30)">
+    <text x="22" y="14" font-size="35px">${
+  (data[0].percentage * 100).toString().substring(0, 4)
+}% complete</text>
   </g>
 </svg>`;
 

--- a/visualisation/simulation.ts
+++ b/visualisation/simulation.ts
@@ -17,33 +17,33 @@ import { radius } from "./directed-graph.ts";
 
 const ORIGIN_STRENGTH = 0.06; // default 0.1
 
-const simulation = forceSimulation<Node, Link>()
-  .force(
-    "link",
-    forceLink<Node, Link>()
-      .id((n) => n.id)
-      .strength(0),
-  )
-  // .force("charge", forceManyBody<Node>())
-  .force(
-    "collide",
-    forceCollide<Node>((d) => radius(d) + 6),
-  )
-  // .force("center", forceCenter(width / 2, height / 2))
-  .force(
-    "x",
-    forceX<Node>()
-      .x((n: Node) => xOrigin(n.folder))
-      .strength(ORIGIN_STRENGTH),
-  )
-  .force(
-    "y",
-    forceY<Node>()
-      .y((n) => yOrigin(n.imports))
-      .strength(ORIGIN_STRENGTH),
-  );
+const updateSimulationData = (data: Data, folders: string[]) => {
+  const simulation = forceSimulation<Node, Link>()
+    .force(
+      "link",
+      forceLink<Node, Link>()
+        .id((n) => n.id)
+        .strength(0),
+    )
+    // .force("charge", forceManyBody<Node>())
+    .force(
+      "collide",
+      forceCollide<Node>((d) => radius(d) + 6),
+    )
+    // .force("center", forceCenter(width / 2, height / 2))
+    .force(
+      "x",
+      forceX<Node>()
+        .x((n: Node) => xOrigin(n.folder, folders))
+        .strength(ORIGIN_STRENGTH),
+    )
+    .force(
+      "y",
+      forceY<Node>()
+        .y((n) => yOrigin(n.imports))
+        .strength(ORIGIN_STRENGTH),
+    );
 
-const updateSimulationData = (data: Data) => {
   const { nodes, links } = data;
 
   const oldNodes = simulation.nodes();


### PR DESCRIPTION
## What does this change?

A change to the way that folders are calculated and shown, allowing them to appear and disappear dynamically from the display depending on whether or not they contain files. Previously, folders were defined statically for all branches, meaning they would display even if empty. Now, we check whether folders are populated before displaying, and adjust the x axis scale of the graph accordingly.

A total percentage progress was also added, and some extra details were added to the documentation.

## How to test

Try to build the page locally, using the instructions in the ReadMe in the visualisation folder of this branch.

## Images

Before:

<img width="1347" alt="Screenshot 2022-09-13 at 12 47 45" src="https://user-images.githubusercontent.com/108270776/189893198-5a878ad7-19b1-432c-8f9d-6381c339c2dd.png">

After:

<img width="1399" alt="Screenshot 2022-09-13 at 12 44 27" src="https://user-images.githubusercontent.com/108270776/189893244-1a3a37db-8044-4fae-97a1-02cb06b4e871.png">

After (using another hash where /hosted/ is populated):

<img width="1437" alt="Screenshot 2022-09-13 at 12 44 35" src="https://user-images.githubusercontent.com/108270776/189893376-39de4d8b-407b-45e3-8e6a-3aa296f62873.png">

